### PR TITLE
 Implement mission joining - Actions #10

### DIFF
--- a/src/Components/MissionComponents/EachMission.js
+++ b/src/Components/MissionComponents/EachMission.js
@@ -1,17 +1,22 @@
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinMission } from '../../redux/missions/missionsSlice';
 
 const EachMission = ({ mission }) => {
   const {
     missionName,
     missionDescription,
+    missionId,
   } = mission;
+
+  const dispatch = useDispatch();
 
   return (
     <tr className="each-mission">
       <td>{missionName}</td>
       <td>{missionDescription}</td>
       <td><span className="not-a-member">NOT A MEMBER</span></td>
-      <td><button className="join-mission" type="button">JOIN MISSION</button></td>
+      <td><button className="join-mission" type="button" onClick={() => dispatch(joinMission(missionId))}>JOIN MISSION</button></td>
     </tr>
   );
 };
@@ -20,6 +25,7 @@ EachMission.propTypes = {
   mission: PropTypes.shape({
     missionName: PropTypes.string.isRequired,
     missionDescription: PropTypes.string.isRequired,
+    missionId: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -22,7 +22,14 @@ const initialState = {
 const missionsSlice = createSlice({
   name: 'missions',
   initialState,
-  reducers: {},
+  reducers: {
+    joinMission: (state, action) => {
+      const newState = state.missions.map((mission) => (mission.missionId === action.payload
+        ? ({ ...mission, missionJoin: true })
+        : mission));
+      state.missions = newState;
+    },
+  },
   extraReducers(builder) {
     builder
       .addCase(fetchMissionsData.pending, (state) => {
@@ -36,6 +43,7 @@ const missionsSlice = createSlice({
             missionId: mission.mission_id,
             missionName: mission.mission_name,
             missionDescription: mission.description,
+            missionJoin: false,
           };
           fetchedData.push(data);
         });
@@ -47,5 +55,7 @@ const missionsSlice = createSlice({
       });
   },
 });
+
+export const { joinMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;


### PR DESCRIPTION
#10 - Implement mission joining Action.

### Introduced changes:
* Add an `joinMission` reducer that changes the `missionJoin` key from default `false` to `true` based on the `payload` action.
* In the `EachMission` component used the `useDispatch` to get the reducer action.
* Included the onClick event with an instant arrow function that calls the dispatch action.