### PR TITLE
Render filter missions

### DIFF
--- a/src/Components/MissionComponents/EachMission.js
+++ b/src/Components/MissionComponents/EachMission.js
@@ -1,22 +1,31 @@
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { joinMission } from '../../redux/missions/missionsSlice';
+import { joinMission, leaveMission } from '../../redux/missions/missionsSlice';
 
 const EachMission = ({ mission }) => {
   const {
     missionName,
     missionDescription,
     missionId,
+    missionJoin,
   } = mission;
 
   const dispatch = useDispatch();
+
+  const checkStatus = () => {
+    if (missionJoin) {
+      dispatch(leaveMission(missionId));
+    } else {
+      dispatch(joinMission(missionId));
+    }
+  };
 
   return (
     <tr className="each-mission">
       <td>{missionName}</td>
       <td>{missionDescription}</td>
       <td><span className="not-a-member">NOT A MEMBER</span></td>
-      <td><button className="join-mission" type="button" onClick={() => dispatch(joinMission(missionId))}>JOIN MISSION</button></td>
+      <td><button className="join-mission" type="button" onClick={checkStatus}>JOIN MISSION</button></td>
     </tr>
   );
 };
@@ -26,6 +35,7 @@ EachMission.propTypes = {
     missionName: PropTypes.string.isRequired,
     missionDescription: PropTypes.string.isRequired,
     missionId: PropTypes.string.isRequired,
+    missionJoin: PropTypes.bool.isRequired,
   }).isRequired,
 };
 

--- a/src/Components/MissionComponents/EachMission.js
+++ b/src/Components/MissionComponents/EachMission.js
@@ -1,17 +1,22 @@
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinMission } from '../../redux/missions/missionsSlice';
 
 const EachMission = ({ mission }) => {
   const {
     missionName,
     missionDescription,
+    missionId,
   } = mission;
+
+  const dispatch = useDispatch();
 
   return (
     <tr className="each-mission">
       <td>{missionName}</td>
       <td>{missionDescription}</td>
       <td><span className="not-a-member">NOT A MEMBER</span></td>
-      <td><button className="join-mission" type="button">JOIN MISSION</button></td>
+      <td><button className="join-mission" type="button" onClick={() => dispatch(joinMission(missionId))}>JOIN MISSION</button></td>
     </tr>
   );
 };
@@ -20,6 +25,7 @@ EachMission.propTypes = {
   mission: PropTypes.shape({
     missionName: PropTypes.string.isRequired,
     missionDescription: PropTypes.string.isRequired,
+    missionId: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/src/Components/MissionComponents/EachMission.js
+++ b/src/Components/MissionComponents/EachMission.js
@@ -24,8 +24,8 @@ const EachMission = ({ mission }) => {
     <tr className="each-mission">
       <td>{missionName}</td>
       <td>{missionDescription}</td>
-      <td><span className="not-a-member">NOT A MEMBER</span></td>
-      <td><button className="join-mission" type="button" onClick={checkStatus}>JOIN MISSION</button></td>
+      <td><span className={missionJoin ? 'active-member' : 'not-a-member'}>{missionJoin ? 'Active Memeber' : 'NOT A MEMBER'}</span></td>
+      <td><button className={missionJoin ? 'leave-mission' : 'join-mission'} type="button" onClick={checkStatus}>{missionJoin ? 'Leave Mission' : 'Join Mission'}</button></td>
     </tr>
   );
 };

--- a/src/Components/MissionComponents/FilterMissions.js
+++ b/src/Components/MissionComponents/FilterMissions.js
@@ -1,0 +1,27 @@
+import { useSelector } from 'react-redux';
+
+const FilteredMissions = () => {
+  const missions = useSelector((state) => state.missions.missions);
+  const currentMissions = missions.filter((mission) => mission.missionJoin);
+
+  return (
+    <>
+      <div className="filtered-missions">
+        <h2>My Missions</h2>
+        {currentMissions.length === 0 ? (
+          <div className="each-mission-name">
+            No current missions
+          </div>
+        ) : (
+          <div className="mission-names">
+            {currentMissions.map((mission) => (
+              <div className="each-mission-name" key={mission.missionId}>{mission.missionName}</div>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default FilteredMissions;

--- a/src/Components/MyProfilePage.js
+++ b/src/Components/MyProfilePage.js
@@ -1,5 +1,12 @@
+import FilteredMissions from './MissionComponents/FilterMissions';
+import '../styles/Profile.css';
+
 const Profile = () => (
-  <h1>Profile page</h1>
+  <>
+    <div className="profile-outer">
+      <FilteredMissions />
+    </div>
+  </>
 );
 
 export default Profile;

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -22,7 +22,14 @@ const initialState = {
 const missionsSlice = createSlice({
   name: 'missions',
   initialState,
-  reducers: {},
+  reducers: {
+    joinMission: (state, action) => {
+      const newState = state.missions.map((mission) => (mission.missionId === action.payload
+        ? ({ ...mission, missionJoin: true })
+        : mission));
+      state.missions = newState;
+    },
+  },
   extraReducers(builder) {
     builder
       .addCase(fetchMissionsData.pending, (state) => {
@@ -36,6 +43,7 @@ const missionsSlice = createSlice({
             missionId: mission.mission_id,
             missionName: mission.mission_name,
             missionDescription: mission.description,
+            missionJoin: false,
           };
           fetchedData.push(data);
         });
@@ -47,5 +55,7 @@ const missionsSlice = createSlice({
       });
   },
 });
+
+export const { joinMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -29,6 +29,12 @@ const missionsSlice = createSlice({
         : mission));
       state.missions = newState;
     },
+    leaveMission: (state, action) => {
+      const newState = state.missions.map((mission) => (mission.missionId === action.payload
+        ? ({ ...mission, missionJoin: false })
+        : mission));
+      state.missions = newState;
+    },
   },
   extraReducers(builder) {
     builder
@@ -56,6 +62,6 @@ const missionsSlice = createSlice({
   },
 });
 
-export const { joinMission } = missionsSlice.actions;
+export const { joinMission, leaveMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;

--- a/src/styles/Missions.css
+++ b/src/styles/Missions.css
@@ -14,15 +14,18 @@
 }
 
 .not-a-member,
-.join-mission {
+.join-mission,
+.active-member,
+.leave-mission {
+  min-width: 115px;
   display: flex;
-  min-width: 110px;
   font-stretch: normal;
   font-style: normal;
   line-height: normal;
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 700;
   letter-spacing: normal;
+  justify-content: center;
 }
 
 .not-a-member {
@@ -32,9 +35,24 @@
   border-radius: 4px;
 }
 
+.active-member {
+  background: #20bbbd;
+  color: #fff;
+  padding: 0.2rem;
+  border-radius: 4px;
+}
+
 .join-mission {
   background: none;
   padding: 0.6rem 0.3rem;
+  border-radius: 4px;
+}
+
+.leave-mission {
+  border: 1px solid red;
+  padding: 0.6rem 0.3rem;
+  background: none;
+  color: red;
   border-radius: 4px;
 }
 

--- a/src/styles/Profile.css
+++ b/src/styles/Profile.css
@@ -1,0 +1,22 @@
+.profile-outer {
+  display: grid;
+  grid-template-columns: 49% 49%;
+  gap: 2%;
+  padding: 3rem;
+  height: 100%;
+}
+
+.filtered-missions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mission-names {
+  border: 1px solid gray;
+}
+
+.each-mission-name {
+  border-bottom: 1px solid gray;
+  padding: 1.6rem;
+}


### PR DESCRIPTION
### [[2pt] Display joined missions in My profile - Filters #2](https://github.com/tan12082001/react-group-capstone/issues/2)

### Introduced changes: 

* Created an `FilteredMissions` component that uses the `useSelector` hook to know the current state and get the missions.
* Using the `filter()` filtered the missions based on `missionJoin` key.
* Rendered the filtered missions in the `Profile` component.
* Added styles for the MyProfile page.